### PR TITLE
chore(sdk): fix publishConfig to be public

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "@consensys-vertical-apps:registry": "https://npm.pkg.github.com/consensys-vertical-apps"
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixed publishConfig in package.json to be public