### PR TITLE
fix(portfoliodashboard): fixes handleMmiPortfolio method

### DIFF
--- a/packages/portfolioDashboard/src/handleMmiPortfolio.ts
+++ b/packages/portfolioDashboard/src/handleMmiPortfolio.ts
@@ -1,11 +1,8 @@
-import { setDashboardCookie } from "./utils";
-
 export async function handleMmiPortfolio({
   keyringAccounts,
   identities,
   metaMetricsId,
   networks,
-  cookieSetUrls,
   getAccountDetails,
   extensionId,
 }) {
@@ -28,7 +25,7 @@ export async function handleMmiPortfolio({
     return { address, name, custodyType: null };
   });
 
-  const mmiDashboardData = {
+  return {
     accounts,
     networks,
     metrics: {
@@ -36,6 +33,4 @@ export async function handleMmiPortfolio({
       extensionId,
     },
   };
-
-  await setDashboardCookie(mmiDashboardData, cookieSetUrls);
 }


### PR DESCRIPTION
We are returning `mmiDashboardData` in the end, and not setting the dashboard cookie, as it's not needed to be done here.

Relates to: https://github.com/ConsenSys/mmi-extension/pull/579