### PR TITLE
fix(custodyid): missing custodyId property in type

### DIFF
--- a/packages/types/src/types/MetamaskTransaction.ts
+++ b/packages/types/src/types/MetamaskTransaction.ts
@@ -7,6 +7,7 @@ import { IEIP1559TxParams, ILegacyTXParams } from "../ITXParams";
 
 export type MetamaskTransaction = {
   chainId: string;
+  custodyId: string;
   custodyStatus: string;
   dappSuggestedGasFees: {
     gas: string;


### PR DESCRIPTION
Adds `custodyId` to MetamaskTransaction type.