### PR TITLE
fix(map): we were doing a forEach and should be a map in order to ret…

### DIFF
--- a/packages/portfolioDashboard/src/handleMmiPortfolio.ts
+++ b/packages/portfolioDashboard/src/handleMmiPortfolio.ts
@@ -6,7 +6,7 @@ export async function handleMmiPortfolio({
   getAccountDetails,
   extensionId,
 }) {
-  networks.forEach(item => parseInt(item.chainId, 16));
+  const parsedNetworks = networks.map(item => parseInt(item.chainId, 16));
   const accounts = keyringAccounts.map(address => {
     const accountDetails = getAccountDetails(address);
 
@@ -27,7 +27,7 @@ export async function handleMmiPortfolio({
 
   return {
     accounts,
-    networks,
+    networks: parsedNetworks,
     metrics: {
       metaMetricsId,
       extensionId,


### PR DESCRIPTION
The `map()` method returns a new array, whereas the `forEach()` method does not return a new array. 
This was causing the `networks` value to be undefined.