### PR TITLE
Fix showCustodianDeepLink to work with new MM extension

### DIFF
--- a/packages/extension/src/ExtensionUtils.test.ts
+++ b/packages/extension/src/ExtensionUtils.test.ts
@@ -515,7 +515,7 @@ describe("ExtensionUtils", () => {
     it("will run getCustodianConfirmDeepLink and onDeepLinkShown", async () => {
       const params = {
         dispatch: jest.fn(() => ({ deepLink: "link", custodyId: "custodyId" })),
-        MMIActions: {
+        mmiActions: {
           getCustodianSignMessageDeepLink: jest.fn(),
           getCustodianConfirmDeepLink: jest.fn(),
           showCustodyConfirmLink: jest.fn(),
@@ -530,13 +530,13 @@ describe("ExtensionUtils", () => {
         onDeepLinkShown: jest.fn(),
       };
       await showCustodianDeepLink(params);
-      expect(params.MMIActions.getCustodianConfirmDeepLink).toBeCalled();
+      expect(params.mmiActions.getCustodianConfirmDeepLink).toBeCalled();
       expect(params.onDeepLinkShown).toBeCalled();
     });
     it("will run getCustodianSignMessageDeepLink and onDeepLinkShown", async () => {
       const params = {
         dispatch: jest.fn(() => ({ deepLink: "link", custodyId: "custodyId" })),
-        MMIActions: {
+        mmiActions: {
           getCustodianSignMessageDeepLink: jest.fn(),
           getCustodianConfirmDeepLink: jest.fn(),
           showCustodyConfirmLink: jest.fn(),
@@ -551,7 +551,7 @@ describe("ExtensionUtils", () => {
         onDeepLinkShown: jest.fn(),
       };
       await showCustodianDeepLink(params);
-      expect(params.MMIActions.getCustodianSignMessageDeepLink).toBeCalled();
+      expect(params.mmiActions.getCustodianSignMessageDeepLink).toBeCalled();
       expect(params.onDeepLinkShown).toBeCalled();
     });
   });

--- a/packages/extension/src/ExtensionUtils.test.ts
+++ b/packages/extension/src/ExtensionUtils.test.ts
@@ -518,7 +518,6 @@ describe("ExtensionUtils", () => {
         mmiActions: {
           getCustodianSignMessageDeepLink: jest.fn(),
           getCustodianConfirmDeepLink: jest.fn(),
-          showCustodyConfirmLink: jest.fn(),
           setWaitForConfirmDeepLinkDialog: jest.fn(),
         },
         txId: "txId",
@@ -528,6 +527,7 @@ describe("ExtensionUtils", () => {
         custodyId: undefined,
         onDeepLinkFetched: jest.fn(),
         onDeepLinkShown: jest.fn(),
+        showCustodyConfirmLink: jest.fn(),
       };
       await showCustodianDeepLink(params);
       expect(params.mmiActions.getCustodianConfirmDeepLink).toBeCalled();
@@ -539,7 +539,6 @@ describe("ExtensionUtils", () => {
         mmiActions: {
           getCustodianSignMessageDeepLink: jest.fn(),
           getCustodianConfirmDeepLink: jest.fn(),
-          showCustodyConfirmLink: jest.fn(),
           setWaitForConfirmDeepLinkDialog: jest.fn(),
         },
         txId: undefined,
@@ -549,6 +548,7 @@ describe("ExtensionUtils", () => {
         custodyId: "custodyId",
         onDeepLinkFetched: jest.fn(),
         onDeepLinkShown: jest.fn(),
+        showCustodyConfirmLink: jest.fn(),
       };
       await showCustodianDeepLink(params);
       expect(params.mmiActions.getCustodianSignMessageDeepLink).toBeCalled();

--- a/packages/extension/src/ExtensionUtils.ts
+++ b/packages/extension/src/ExtensionUtils.ts
@@ -11,13 +11,12 @@ import { ICustodianUpdate, MetamaskTransaction, MetaMaskTransactionStatuses } fr
 
 const TRANSACTION_EVENTS: { [key in MetaMaskTransactionStatuses]: string } = {
   [MetaMaskTransactionStatuses.APPROVED]: "Transaction Approved",
-  [MetaMaskTransactionStatuses.SIGNED]: "Transaction Finalized",
+  [MetaMaskTransactionStatuses.SIGNED]: "Transaction Signed",
   [MetaMaskTransactionStatuses.REJECTED]: "Transaction Rejected",
   [MetaMaskTransactionStatuses.FAILED]: "Transaction Failed",
   [MetaMaskTransactionStatuses.SUBMITTED]: "Transaction Submitted",
   [MetaMaskTransactionStatuses.CONFIRMED]: "Transaction Confirmed",
   [MetaMaskTransactionStatuses.UNAPPROVED]: "Transaction Unapproved",
-  [MetaMaskTransactionStatuses.SIGNED]: "Transaction Signed",
   [MetaMaskTransactionStatuses.DROPPED]: "Transaction Dropped",
 };
 
@@ -201,7 +200,7 @@ export function custodianEventHandlerFactory({
 
 interface ShowCustodianDeepLinkParameters {
   dispatch: (any) => any;
-  MMIActions: any;
+  mmiActions: any;
   txId: string;
   fromAddress: string;
   closeNotification: boolean;
@@ -209,11 +208,12 @@ interface ShowCustodianDeepLinkParameters {
   custodyId: string;
   onDeepLinkFetched: () => any;
   onDeepLinkShown: () => any;
+  showCustodyConfirmLink: (any) => any;
 }
 
 export async function showCustodianDeepLink({
   dispatch,
-  MMIActions,
+  mmiActions,
   txId,
   fromAddress,
   closeNotification,
@@ -221,31 +221,32 @@ export async function showCustodianDeepLink({
   custodyId,
   onDeepLinkFetched,
   onDeepLinkShown,
+  showCustodyConfirmLink,
 }: ShowCustodianDeepLinkParameters): Promise<void> {
   let deepLink;
   let custodianTxId = custodyId;
   if (isSignature) {
-    const link = await dispatch(MMIActions.getCustodianSignMessageDeepLink(fromAddress, custodyId));
+    const link = await dispatch(mmiActions.getCustodianSignMessageDeepLink(fromAddress, custodyId));
     deepLink = link;
   } else {
-    const result = await dispatch(MMIActions.getCustodianConfirmDeepLink(txId));
+    const result = await dispatch(mmiActions.getCustodianConfirmDeepLink(txId));
     deepLink = result.deepLink;
     custodianTxId = result.custodyId;
   }
   onDeepLinkFetched();
   try {
     await dispatch(
-      MMIActions.showCustodyConfirmLink({
+      showCustodyConfirmLink({
         link: deepLink,
         address: fromAddress,
         closeNotification: closeNotification,
         custodyId: custodianTxId,
       }),
     );
-    dispatch(MMIActions.setWaitForConfirmDeepLinkDialog(true));
+    dispatch(mmiActions.setWaitForConfirmDeepLinkDialog(true));
     onDeepLinkShown();
   } catch (e) {
-    dispatch(MMIActions.setWaitForConfirmDeepLinkDialog(false));
+    dispatch(mmiActions.setWaitForConfirmDeepLinkDialog(false));
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,11 +1310,6 @@
     crypto "^1.0.1"
     lodash.clonedeep "^4.5.0"
 
-"@metamask-institutional/types@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@metamask-institutional/types/-/types-1.0.3.tgz#a774fb6e6babb58e702d8c56ee078e8f437d8a27"
-  integrity sha512-XPE53SI5uXxOhrc+3rbAVFqpJUL3qoAMKK4M9qj8efSyFkw0/tuy7zGdEP8JTPr/oCvumo1uROBZCmcvskZEUQ==
-
 "@metamask/approval-controller@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@metamask/approval-controller/-/approval-controller-2.1.1.tgz#c8731ddaaa8e29c1ab5355f87116b3f20a7e6c0d"


### PR DESCRIPTION
Fixed extensionUtils showCustodianDeepLink method. We passed down showCustodyConfirmLink action from the extension. Also we renamed MMIActions to mmiActions.