### PR TITLE
chore(custodianEventHandlerFactory): mmi personal sign & sign typed logic

### DIFF
--- a/packages/custodyKeyring/src/custodianTypes/json-rpc/JsonRpcCustodyKeyring.ts
+++ b/packages/custodyKeyring/src/custodianTypes/json-rpc/JsonRpcCustodyKeyring.ts
@@ -59,7 +59,6 @@ export class JsonRpcCustodyKeyring extends CustodyKeyring {
       return transactionLink;
     } catch (e) {
       console.log(`Unable to get transction link for ${txId}`);
-      console.log(e);
       return null;
     }
   };

--- a/packages/extension/src/ExtensionUtils.test.ts
+++ b/packages/extension/src/ExtensionUtils.test.ts
@@ -29,15 +29,16 @@ describe("ExtensionUtils", () => {
     addKeyringIfNotExists: () => keyring,
     getPendingNonce: jest.fn(() => Promise.resolve(2)),
     setTxHash: jest.fn(),
-    typedMessageManager: {
-      getMsgByCustodyId: jest.fn(() => "msgId"),
-      setMsgStatusSigned: jest.fn(),
-      rejectMsg: jest.fn(),
-    },
-    personalMessageManager: {
-      getMsgByCustodyId: jest.fn(() => "msgId"),
-      setMsgStatusSigned: jest.fn(),
-      rejectMsg: jest.fn(),
+    signatureController: {
+      messages: {
+        0: {
+          metadata: {
+            custodian_transactionId: "0x1",
+          },
+        },
+      },
+      setMessageStatusSigned: jest.fn(),
+      cancelAbstractMessage: jest.fn(),
     },
     txStateManager: {
       getTransactions: jest.fn(() => [
@@ -148,7 +149,7 @@ describe("ExtensionUtils", () => {
           id: "0x1", // This must match the signature ID from the custodian_sign or custodian_signTypeData method
           address: "0x1", // Hexlified
           signatureVersion: "personal",
-          signature: "0xdeadbeef",
+          signature: "jfndiwkdk",
           status: {
             finished: true,
             signed: true,
@@ -161,8 +162,14 @@ describe("ExtensionUtils", () => {
 
       await eventHandler(event as ICustodianUpdate);
 
-      expect(params.personalMessageManager.getMsgByCustodyId).toHaveBeenCalledWith(event.signedMessage.id);
-      expect(params.personalMessageManager.setMsgStatusSigned).toHaveBeenCalled();
+      expect(params.signatureController.messages).toStrictEqual({
+        0: {
+          metadata: {
+            custodian_transactionId: "0x1",
+          },
+        },
+      });
+      expect(params.signatureController.setMessageStatusSigned).toHaveBeenCalled();
     });
 
     it("can handle a personal_sign rejected message", async () => {
@@ -198,7 +205,7 @@ describe("ExtensionUtils", () => {
 
       await eventHandler(event as unknown as ICustodianUpdate);
 
-      expect(params.personalMessageManager.setMsgStatusSigned).toHaveBeenCalledTimes(0);
+      expect(params.signatureController.setMessageStatusSigned).toHaveBeenCalledTimes(0);
     });
 
     it("can handle a sign message that failed", async () => {
@@ -234,7 +241,7 @@ describe("ExtensionUtils", () => {
 
       await eventHandler(event as unknown as ICustodianUpdate);
 
-      expect(params.personalMessageManager.setMsgStatusSigned).toHaveBeenCalledTimes(0);
+      expect(params.signatureController.setMessageStatusSigned).toHaveBeenCalledTimes(0);
     });
 
     it("will process an update", async () => {
@@ -255,15 +262,10 @@ describe("ExtensionUtils", () => {
         addKeyringIfNotExists: () => keyring,
         getPendingNonce: jest.fn(() => Promise.resolve(2)),
         setTxHash: jest.fn(),
-        typedMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
-        },
-        personalMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
+        signatureController: {
+          messages: {},
+          setMessageStatusSigned: jest.fn(),
+          cancelAbstractMessage: jest.fn(),
         },
         txStateManager: {
           getTransactions: jest.fn(() => [
@@ -337,15 +339,10 @@ describe("ExtensionUtils", () => {
         addKeyringIfNotExists: () => keyring,
         getPendingNonce: jest.fn(() => Promise.resolve(2)),
         setTxHash: jest.fn(),
-        typedMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
-        },
-        personalMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
+        signatureController: {
+          messages: {},
+          setMessageStatusSigned: jest.fn(),
+          cancelAbstractMessage: jest.fn(),
         },
         txStateManager: {
           getTransactions: jest.fn(() => [
@@ -400,15 +397,10 @@ describe("ExtensionUtils", () => {
         addKeyringIfNotExists: () => keyring,
         getPendingNonce: jest.fn(() => Promise.resolve(2)),
         setTxHash: jest.fn(),
-        typedMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
-        },
-        personalMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
+        signatureController: {
+          messages: {},
+          setMessageStatusSigned: jest.fn(),
+          cancelAbstractMessage: jest.fn(),
         },
         txStateManager: {
           getTransactions: jest.fn(() => [
@@ -465,15 +457,10 @@ describe("ExtensionUtils", () => {
         addKeyringIfNotExists: () => keyring,
         getPendingNonce: jest.fn(() => Promise.resolve(2)),
         setTxHash: jest.fn(),
-        typedMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
-        },
-        personalMessageManager: {
-          getMsgByCustodyId: jest.fn(() => "msgId"),
-          setMsgStatusSigned: jest.fn(),
-          rejectMsg: jest.fn(),
+        signatureController: {
+          messages: {},
+          setMessageStatusSigned: jest.fn(),
+          cancelAbstractMessage: jest.fn(),
         },
         txStateManager: {
           getTransactions: jest.fn(() => [

--- a/packages/extension/src/ExtensionUtils.ts
+++ b/packages/extension/src/ExtensionUtils.ts
@@ -154,7 +154,7 @@ export function custodianEventHandlerFactory({
       const allMessages = signatureController.messages;
       const filteredItem = Object.keys(allMessages)
         .map(key => allMessages[key])
-        .find(item => item.metadata.custodian_transactionId === txData.signedMessage.id);
+        .find(item => item.metadata?.custodian_transactionId === txData.signedMessage.id);
 
       if (!filteredItem) {
         return;

--- a/packages/extension/src/ExtensionUtils.ts
+++ b/packages/extension/src/ExtensionUtils.ts
@@ -100,8 +100,7 @@ interface CustodianEventHandlerFactoryParameters {
   log: any;
   getPendingNonce: (string) => Promise<number>;
   setTxHash: (number, string) => void;
-  typedMessageManager: any;
-  personalMessageManager: any;
+  signatureController: any;
   txStateManager: any;
   custodyController: CustodyController;
   trackTransactionEvent: (txMeta: MetamaskTransaction, string) => void;
@@ -114,8 +113,7 @@ export function custodianEventHandlerFactory({
   log,
   getPendingNonce,
   setTxHash,
-  typedMessageManager,
-  personalMessageManager,
+  signatureController,
   txStateManager,
   custodyController,
   trackTransactionEvent,
@@ -153,25 +151,23 @@ export function custodianEventHandlerFactory({
         custodyController.setWaitForConfirmDeepLinkDialog(false);
       }
 
-      if (!/personal/.test(txData.signedMessage.signatureVersion)) {
-        // EIP-712 signature
-        const msgId = typedMessageManager.getMsgByCustodyId(txData.signedMessage.id)?.id;
+      const allMessages = signatureController.messages;
+      const filteredItem = Object.keys(allMessages)
+        .map(key => allMessages[key])
+        .find(item => item.metadata.custodian_transactionId === txData.signedMessage.id);
 
-        if (txData.signedMessage.signature && txData.signedMessage.signature != "0x") {
-          typedMessageManager.setMsgStatusSigned(msgId, txData.signedMessage.signature);
-        } else if (txData.signedMessage.status.finished && !txData.signedMessage.status.success) {
-          typedMessageManager.rejectMsg(msgId);
-        }
-      } else {
-        const msgId = personalMessageManager.getMsgByCustodyId(txData.signedMessage.id)?.id;
-        console.log(personalMessageManager.getMsgByCustodyId(txData.signedMessage.id));
-
-        if (txData.signedMessage.signature && txData.signedMessage.signature != "0x") {
-          personalMessageManager.setMsgStatusSigned(msgId, txData.signedMessage.signature);
-        } else if (txData.signedMessage.status.finished && !txData.signedMessage.status.success) {
-          personalMessageManager.rejectMsg(msgId);
-        }
+      if (!filteredItem) {
+        return;
       }
+
+      const messageId = filteredItem.id;
+
+      if (txData.signedMessage.signature && txData.signedMessage.signature != "0x") {
+        signatureController.setMessageStatusSigned(messageId, txData.signedMessage.signature);
+      } else if (txData.signedMessage.status.finished && !txData.signedMessage.status.success) {
+        signatureController.cancelAbstractMessage(messageId);
+      }
+
       return;
     }
 

--- a/packages/mmiController/src/MMIController.ts
+++ b/packages/mmiController/src/MMIController.ts
@@ -1,6 +1,9 @@
+// @TODO Do not use this controller
+// needs to be updated with the latest version in:
+// https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/mmi-controller.js
 import { CustodyController } from "@metamask-institutional/custody-controller";
 import { CUSTODIAN_TYPES, MmiConfigurationController } from "@metamask-institutional/custody-keyring";
-import { custodianEventHandlerFactory, updateCustodianTransactions } from "@metamask-institutional/extension";
+import { updateCustodianTransactions } from "@metamask-institutional/extension";
 import { InstitutionalFeaturesController } from "@metamask-institutional/institutional-features";
 import { handleMmiPortfolio } from "@metamask-institutional/portfolio-dashboard";
 import { INTERACTIVE_REPLACEMENT_TOKEN_CHANGE_EVENT, REFRESH_TOKEN_CHANGE_EVENT } from "@metamask-institutional/sdk";
@@ -103,7 +106,7 @@ export class MMIController extends EventEmitter {
     this.networkController = networkController;
 
     // Prepare event listener after transactionUpdateController gets initiated
-    this.transactionUpdateController.prepareEventListener(this.custodianEventHandlerFactory.bind(this));
+    // this.transactionUpdateController.prepareEventListener(this.custodianEventHandlerFactory.bind(this));
 
     // Get configuration from MMIConfig controller
     if (!process.env.IN_TEST) {
@@ -132,19 +135,19 @@ export class MMIController extends EventEmitter {
     return keyring;
   }
 
-  custodianEventHandlerFactory() {
-    return custodianEventHandlerFactory({
-      log,
-      getState: () => this.getState(),
-      getPendingNonce: address => this.getPendingNonce(address),
-      setTxHash: (txId, txHash) => this.txController.setTxHash(txId, txHash),
-      typedMessageManager: this.typedMessageManager,
-      personalMessageManager: this.personalMessageManager,
-      txStateManager: this.txController.txStateManager,
-      custodyController: this.custodyController,
-      trackTransactionEvent: this.trackTransactionEventFromCustodianEvent.bind(this),
-    });
-  }
+  // custodianEventHandlerFactory() {
+  //   return custodianEventHandlerFactory({
+  //     log,
+  //     getState: () => this.getState(),
+  //     getPendingNonce: address => this.getPendingNonce(address),
+  //     setTxHash: (txId, txHash) => this.txController.setTxHash(txId, txHash),
+  //     typedMessageManager: this.typedMessageManager,
+  //     personalMessageManager: this.personalMessageManager,
+  //     txStateManager: this.txController.txStateManager,
+  //     custodyController: this.custodyController,
+  //     trackTransactionEvent: this.trackTransactionEventFromCustodianEvent.bind(this),
+  //   });
+  // }
 
   async storeCustodianSupportedChains(address: string) {
     const custodyType = this.custodyController.getCustodyTypeByAddress(toChecksumHexAddress(address));


### PR DESCRIPTION
Updates `custodianEventHandlerFactory` to use the `signatureController` from Core, instead of the current  `typedMessageManager` and `personalMessageManager`.

In order to set a message as signed, we are now getting all the messages from `signatureController.messages`, filtering out the one that has the `custodian_transactionId`  matching the `id` coming in `txData`:

`item.metadata.custodian_transactionId === txData.signedMessage.id`