### PR TITLE
fix(custodykeyring): Fixed cannot read properties of undefined in custody keyring

### DIFF
--- a/packages/custodyKeyring/src/migrations/001.ts
+++ b/packages/custodyKeyring/src/migrations/001.ts
@@ -4,7 +4,7 @@ import cloneDeep from "lodash.clonedeep";
 import { CustodyKeyring } from "../CustodyKeyring";
 
 const version = 1;
-const keyringTypesToChange = ["Custody - Curv", "Custody - Qredo", "Custody - Jupiter"];
+const keyringTypesToChange = []; // Do not actually change any keyrings - 21 Aug 2023 - we only keep this old migration file around as an example
 
 export default {
   version,


### PR DESCRIPTION
## Description

We don't want to run the migrations as they are very old and they are causing some issues. We keep the file as an example