### PR TITLE
fix(custodykeyring): the getAccounts method should return a new array

### DIFF
--- a/packages/custodyKeyring/src/CustodyKeyring.ts
+++ b/packages/custodyKeyring/src/CustodyKeyring.ts
@@ -169,7 +169,7 @@ export abstract class CustodyKeyring extends EventEmitter {
   }
 
   getAccounts() {
-    return Promise.resolve(this.accounts);
+    return Promise.resolve(this.accounts.slice());
   }
 
   removeAccount(address: string): void {


### PR DESCRIPTION
The `getAccounts` method should return a copy of the original array of the accounts, hence using the `.slice()`.
