### PR TITLE
fix(content-type): setting content-type as json

### DIFF
--- a/packages/sdk/src/custodianApi/cactus/CactusClient.test.ts
+++ b/packages/sdk/src/custodianApi/cactus/CactusClient.test.ts
@@ -55,6 +55,9 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/tokens`, {
         body: '{"grantType":"refresh_token","refreshToken":"mock-refresh-token"}',
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
       });
     });
   });
@@ -74,6 +77,7 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/eth-accounts`, {
         headers: {
           Authorization: `Bearer 123`,
+          "Content-Type": "application/json",
         },
       });
 
@@ -121,6 +125,7 @@ describe("CactusClient", () => {
         body: '{"to":"test","from":"test","value":"test","data":"test","gasLimit":"test","note":"hello","gasPrice":"test"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -153,6 +158,7 @@ describe("CactusClient", () => {
         body: '{"to":"test","from":"test","value":"test","data":"test","gasLimit":"test","note":"Hello","maxPriorityFeePerGas":"test","maxFeePerGas":"test"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -193,6 +199,7 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/signatures?transactionId=xxx`, {
         headers: {
           Authorization: `Bearer 123`,
+          "Content-Type": "application/json",
         },
       });
 
@@ -230,6 +237,7 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/transactions?chainId=4`, {
         headers: {
           Authorization: `Bearer 123`,
+          "Content-Type": "application/json",
         },
       });
 
@@ -259,6 +267,7 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/transactions?transactionId=xxx`, {
         headers: {
           Authorization: `Bearer 123`,
+          "Content-Type": "application/json",
         },
       });
 
@@ -298,6 +307,7 @@ describe("CactusClient", () => {
         body: "{}",
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -338,6 +348,7 @@ describe("CactusClient", () => {
         body: '{"address":"test","payload":{"types":{"EIP712Domain":[]},"primaryType":"test","domain":{"name":"test"},"message":{}},"signatureVersion":"V4"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -363,6 +374,7 @@ describe("CactusClient", () => {
         body: '{"address":"test","payload":{"types":{"EIP712Domain":[]},"primaryType":"test","domain":{"name":"test"},"message":{}},"signatureVersion":"V4"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -405,6 +417,7 @@ describe("CactusClient", () => {
         body: '{"address":"test","payload":{"message":"0xdeadbeef"},"signatureVersion":"personalSign"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -434,6 +447,7 @@ describe("CactusClient", () => {
       expect(fetchMock).toHaveBeenCalledWith(`${mockUrl}/chainIds`, {
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
       });
     });

--- a/packages/sdk/src/custodianApi/cactus/CactusClient.ts
+++ b/packages/sdk/src/custodianApi/cactus/CactusClient.ts
@@ -25,6 +25,7 @@ export class CactusClient {
     });
 
     return {
+      "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     };
   }
@@ -33,6 +34,9 @@ export class CactusClient {
     try {
       const response = await fetch(`${this.apiUrl}/tokens`, {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           grantType: "refresh_token",
           refreshToken: this.refreshToken,

--- a/packages/sdk/src/custodianApi/qredo/QredoClient.test.ts
+++ b/packages/sdk/src/custodianApi/qredo/QredoClient.test.ts
@@ -92,6 +92,7 @@ describe("#QredoClient", () => {
       expect(fetchMock).toHaveBeenCalledWith("https://qredo/connect/wallets", {
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
       });
     });
@@ -142,7 +143,10 @@ describe("#QredoClient", () => {
 
       expect(fetchMock).toHaveBeenCalledWith(`https://qredo/connect/transaction`, {
         body: '{"to":"test","from":"0xtest","value":"test","data":"test","gasLimit":"test","chainID":"42","maxPriorityFeePerGas":"test","maxFeePerGas":"test"}',
-        headers: { Authorization: "Bearer 123" },
+        headers: {
+          Authorization: "Bearer 123",
+          "Content-Type": "application/json",
+        },
         method: "POST",
       });
     });
@@ -183,6 +187,7 @@ describe("#QredoClient", () => {
       expect(fetchMock).toHaveBeenCalledWith("https://qredo/connect/transaction/xxx", {
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
       });
 
@@ -232,7 +237,10 @@ describe("#QredoClient", () => {
       await qredoClient.getCustomerProof();
 
       expect(fetchMock).toHaveBeenLastCalledWith("https://qredo/connect/customer-proof", {
-        headers: { Authorization: "Bearer 123" },
+        headers: {
+          Authorization: "Bearer 123",
+          "Content-Type": "application/json",
+        },
         method: "POST",
       });
     });
@@ -247,6 +255,7 @@ describe("#QredoClient", () => {
       expect(fetchMock).toHaveBeenCalledWith("https://qredo/connect/sign/xxx", {
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
       });
 
@@ -276,6 +285,7 @@ describe("#QredoClient", () => {
       expect(fetchMock).toHaveBeenCalledWith("https://qredo/connect/networks", {
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
       });
     });
@@ -306,6 +316,7 @@ describe("#QredoClient", () => {
         body: '{"from":"test","message":"0xdeadbeef"}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });
@@ -347,6 +358,7 @@ describe("#QredoClient", () => {
         body: '{"from":"test","payload":{"types":{"EIP712Domain":[]},"primaryType":"test","domain":{"name":"test"},"message":{}}}',
         headers: {
           Authorization: "Bearer 123",
+          "Content-Type": "application/json",
         },
         method: "POST",
       });

--- a/packages/sdk/src/custodianApi/qredo/QredoClient.ts
+++ b/packages/sdk/src/custodianApi/qredo/QredoClient.ts
@@ -30,6 +30,7 @@ export class QredoClient extends EventEmitter {
     });
 
     return {
+      "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     };
   }

--- a/packages/sdk/src/custodianApi/qredo/QredoCustodianApi.ts
+++ b/packages/sdk/src/custodianApi/qredo/QredoCustodianApi.ts
@@ -125,7 +125,7 @@ export class QredoCustodianApi extends EventEmitter implements ICustodianApi {
       gasPrice: result.gasPrice,
       maxFeePerGas: null,
       maxPriorityFeePerGas: null,
-      nonce: result.nonce.toString(10),
+      nonce: result.nonce?.toString(10),
       transactionHash: result.txHash,
     };
   }


### PR DESCRIPTION
We can't trust that fetch() will choose the content type correctly if none is set in the [options](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options) parameter.