### PR TITLE
fix(custody-keyring): get apiUrl from custody type

### DIFF
--- a/packages/custodyKeyring/src/custodianTypes/bitgo/BitgoCustodyKeyring.ts
+++ b/packages/custodyKeyring/src/custodianTypes/bitgo/BitgoCustodyKeyring.ts
@@ -46,8 +46,7 @@ export class BitgoCustodyKeyring extends CustodyKeyring {
   };
 
   sdkFactory = (authDetails: AuthDetails, envName: string): MMISDK => {
-    const { apiUrl } = this.getCustodianFromEnvName(envName);
-    return mmiSDKFactory(BitgoCustodianApi, authDetails, this.authType, apiUrl);
+    return mmiSDKFactory(BitgoCustodianApi, authDetails, this.authType, this.custodianType.apiUrl);
   };
 
   txDeepLink = async (_custodianDetails, _txId) => {

--- a/packages/custodyKeyring/src/custodianTypes/cactus/CactusCustodyKeyring.ts
+++ b/packages/custodyKeyring/src/custodianTypes/cactus/CactusCustodyKeyring.ts
@@ -45,8 +45,7 @@ export class CactusCustodyKeyring extends CustodyKeyring {
   public static addressType: AddressType.POLYCHAIN;
 
   sdkFactory = (authDetails: IRefreshTokenAuthDetails, envName: string): MMISDK => {
-    const { apiUrl } = this.getCustodianFromEnvName(envName);
-    return mmiSDKFactory(CactusCustodianApi, authDetails, this.authType, apiUrl);
+    return mmiSDKFactory(CactusCustodianApi, authDetails, this.authType, this.custodianType.apiUrl);
   };
 
   txDeepLink = async (_custodianDetails, _txId): Promise<Partial<ICustodianTransactionLink>> => {

--- a/packages/custodyKeyring/src/custodianTypes/qredo/QredoCustodyKeyring.ts
+++ b/packages/custodyKeyring/src/custodianTypes/qredo/QredoCustodyKeyring.ts
@@ -18,7 +18,7 @@ export class QredoCustodyKeyring extends CustodyKeyring {
   public readonly custodianType = {
     name: "Qredo",
     displayName: "Qredo",
-    apiUrl: "https://api.qredo.network",
+    apiUrl: "https://api-v2.qredo.network/api/v2",
     imgSrc: "https://dashboard.metamask-institutional.io/custodian-icons/qredo-icon.svg",
     icon: "https://dashboard.metamask-institutional.io/custodian-icons/qredo-icon.svg",
     website: "https://www.qredo.com",
@@ -45,8 +45,7 @@ export class QredoCustodyKeyring extends CustodyKeyring {
   public static addressType: AddressType.POLYCHAIN;
 
   sdkFactory = (authDetails: IRefreshTokenAuthDetails, envName: string): MMISDK => {
-    const { apiUrl } = this.getCustodianFromEnvName(envName);
-    return mmiSDKFactory(QredoCustodianApi, authDetails, this.authType, apiUrl);
+    return mmiSDKFactory(QredoCustodianApi, authDetails, this.authType, this.custodianType.apiUrl);
   };
 
   txDeepLink = async (_address: string, _txId: string): Promise<Partial<ICustodianTransactionLink>> => {


### PR DESCRIPTION
Retrieves the API URL from the custodian type for these legacy custodians.