### PR TITLE
refactor(rpc-allowlist): eliminates usage of regex to check origins

### DIFF
--- a/packages/rpcAllowlist/src/index.ts
+++ b/packages/rpcAllowlist/src/index.ts
@@ -1,1 +1,1 @@
-export { RPC_ALLOWED_ORIGINS } from "./rpc-allowed-origins";
+export { isAllowedRPCOrigin } from "./rpc-allowed-origins";

--- a/packages/rpcAllowlist/src/rpc-allowed-origins.test.ts
+++ b/packages/rpcAllowlist/src/rpc-allowed-origins.test.ts
@@ -1,0 +1,32 @@
+import { isAllowedRPCOrigin } from "./rpc-allowed-origins";
+
+describe("isAllowedRPCOrigin", () => {
+  ["metamaskinstitutional_portfolio", "metamaskinstitutional_open_swaps"].forEach(messageType => {
+    describe(`when the message type is ${messageType}`, () => {
+      it("returns true for valid local origins", () => {
+        expect(isAllowedRPCOrigin(messageType, "http://localhost:3001")).toBe(true);
+        expect(isAllowedRPCOrigin(messageType, "http://host.docker.internal:3001")).toBe(true);
+      });
+
+      it("returns true for valid MMI subdomains", () => {
+        expect(isAllowedRPCOrigin(messageType, "https://subdomain.metamask-institutional.io")).toBe(true);
+      });
+
+      it("returns false for invalid MMI subdomains", () => {
+        expect(isAllowedRPCOrigin(messageType, "https://subdomain.notmetamask-institutional.io")).toBe(false);
+      });
+
+      it("returns false for urls that are not allowed", () => {
+        expect(isAllowedRPCOrigin(messageType, "https://anything.com/.metamask-institutional.io")).toBe(false);
+      });
+
+      it("returns false for valid MMI subdomains not using https", () => {
+        expect(isAllowedRPCOrigin(messageType, "http://subdomain.metamask-institutional.io")).toBe(false);
+      });
+
+      it("returns false for root MMI domain", () => {
+        expect(isAllowedRPCOrigin(messageType, "https://metamask-institutional.io")).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/rpcAllowlist/src/rpc-allowed-origins.ts
+++ b/packages/rpcAllowlist/src/rpc-allowed-origins.ts
@@ -1,12 +1,36 @@
-export const RPC_ALLOWED_ORIGINS = {
-  metamaskinstitutional_portfolio: [
-    /^http:\/\/localhost:3001/,
-    /^http:\/\/host.docker.internal:3001/,
-    /^https:\/\/.+\.metamask-institutional.io/,
-  ],
-  metamaskinstitutional_open_swaps: [
-    /^http:\/\/localhost:3001/,
-    /^http:\/\/host.docker.internal:3001/,
-    /^https:\/\/.+\.metamask-institutional.io/,
-  ],
-};
+const MMI_HOSTNAME = "metamask-institutional.io";
+const LOCAL_ORIGINS = ["http://localhost:3001", "http://host.docker.internal:3001"];
+
+export function isAllowedRPCOrigin(messageType: string, origin: string) {
+  const url = parseUrl(origin);
+
+  if (!url) {
+    return false;
+  }
+
+  switch (messageType) {
+    case "metamaskinstitutional_portfolio":
+    case "metamaskinstitutional_open_swaps":
+      return isValidMMISubdomain(url) || isValidLocalOrigin(url);
+    default:
+      return false;
+  }
+}
+
+function isValidLocalOrigin({ origin }: URL) {
+  return LOCAL_ORIGINS.includes(origin);
+}
+
+function isValidMMISubdomain({ protocol, hostname }: URL) {
+  return protocol === "https:" && hostname.endsWith(`.${MMI_HOSTNAME}`);
+}
+
+function parseUrl(origin: string) {
+  const trimmedOrigin = origin.endsWith("/") ? origin.slice(0, -1) : origin;
+
+  try {
+    return new URL(trimmedOrigin);
+  } catch (error) {
+    return null;
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: A new function will need to be called instead of accessing the regex expressions directly

## Description

This pull request replaces the usage of regex to identify allowlisted origins with logic that leverages javascript's built in URL parsing for more accurate comparisons. In addition, adding tests allows for us to easily catch regressions.

## Motivation and Context

Similar to https://github.com/MetaMask/metamask-extension/pull/23134, we are looking to eliminate the usage of regex as a mechanism to match domains. This is done to prevent any accidental mismatches, and also to improve maintainability. 
## How Has This Been Tested?

Unit tests have been written to ensure the functionality works as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
