### PR TITLE
fix(handlemmiportfolio): returns name for non custodial accounts

### DIFF
--- a/packages/portfolioDashboard/src/handleMmiPortfolio.test.ts
+++ b/packages/portfolioDashboard/src/handleMmiPortfolio.test.ts
@@ -1,0 +1,136 @@
+import { handleMmiPortfolio } from "./handleMmiPortfolio";
+
+export interface Identity {
+  address: string;
+  name: string;
+}
+
+export interface Network {
+  chainId: string;
+}
+
+const mockGetAccountDetails = jest.fn();
+
+describe('handleMmiPortfolio', () => {
+  beforeEach(() => {
+    mockGetAccountDetails.mockClear();
+    jest.clearAllMocks();
+  });
+
+  it('should return empty accounts and networks when inputs are empty', async () => {
+    const result = await handleMmiPortfolio({
+      keyringAccounts: [],
+      identities: [],
+      metaMetricsId: 'test-id',
+      networks: [],
+      getAccountDetails: mockGetAccountDetails,
+      extensionId: 'ext-id',
+    });
+
+    expect(result).toEqual({
+      accounts: [],
+      networks: [],
+      metrics: {
+        metaMetricsId: 'test-id',
+        extensionId: 'ext-id',
+      },
+    });
+  });
+
+  it('should process identities correctly', async () => {
+    const result = await handleMmiPortfolio({
+      keyringAccounts: ['0x123'],
+      identities: [{ address: '0x123', name: 'Account 1' }],
+      metaMetricsId: 'test-id',
+      networks: ['0x1'],
+      getAccountDetails: mockGetAccountDetails,
+      extensionId: 'ext-id',
+    });
+
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts[0].name).toBe('Account 1');
+  });
+
+  it('should handle custodial accounts correctly', async () => {
+    mockGetAccountDetails.mockImplementation(address => ({
+      name: 'Custodial Account',
+      custodyType: 'Custodial',
+      address
+    }));
+
+    const result = await handleMmiPortfolio({
+      keyringAccounts: ['0x123'],
+      identities: [{ address: '0x123', name: 'Account 1' }],
+      metaMetricsId: 'test-id',
+      networks: ['0x1'],
+      getAccountDetails: mockGetAccountDetails,
+      extensionId: 'ext-id',
+    });
+
+    expect(result.accounts[0].custodyType).toBe('Custodial');
+    expect(mockGetAccountDetails).toHaveBeenCalledWith('0x123');
+  });
+
+  it('should avoid adding duplicate accounts', async () => {
+    const result = await handleMmiPortfolio({
+      keyringAccounts: ['0x123', '0x123'],
+      identities: [{ address: '0x123', name: 'Account 1' }, { address: '0x123', name: 'Account 1 Duplicate' }],
+      metaMetricsId: 'test-id',
+      networks: ['0x1'],
+      getAccountDetails: mockGetAccountDetails,
+      extensionId: 'ext-id',
+    });
+
+    expect(result.accounts).toHaveLength(1);
+  });
+
+  it('should handle both custodial and non-custodial accounts correctly', async () => {
+    mockGetAccountDetails.mockImplementation((address: string) => {
+      if (address === '0xCustodial') {
+        return { name: 'Custodial Account', custodyType: 'Custodial' };
+      }
+      return null; // simulate a non custodial account by not returning details
+    });
+
+    const keyringAccounts = ['0xCustodial', '0xNonCustodial'];
+    const identities: Identity[] = [
+      { address: '0xCustodial', name: 'Custodial Account 1' },
+      { address: '0xNonCustodial', name: 'Account 2' },
+    ];
+    const networks: Network[] = [{ chainId: '0x1' }];
+    const metaMetricsId = 'test-id';
+    const extensionId = 'ext-id';
+
+    const result = await handleMmiPortfolio({
+      keyringAccounts,
+      identities,
+      metaMetricsId,
+      networks,
+      getAccountDetails: mockGetAccountDetails,
+      extensionId,
+    });
+
+    // both accounts are included
+    expect(result.accounts).toHaveLength(2);
+
+    // custodial account
+    expect(result.accounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        address: '0xCustodial',
+        name: 'Custodial Account',
+        custodyType: 'Custodial',
+      }),
+    ]));
+
+    // non-custodial account
+    expect(result.accounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        address: '0xNonCustodial',
+        name: 'Account 2',
+        custodyType: null,
+      }),
+    ]));
+
+    expect(mockGetAccountDetails).toHaveBeenCalledWith('0xCustodial');
+  });
+});

--- a/packages/portfolioDashboard/src/handleMmiPortfolio.test.ts
+++ b/packages/portfolioDashboard/src/handleMmiPortfolio.test.ts
@@ -89,7 +89,7 @@ describe('handleMmiPortfolio', () => {
       if (address === '0xCustodial') {
         return { name: 'Custodial Account', custodyType: 'Custodial' };
       }
-      return null; // simulate a non custodial account by not returning details
+      return null;
     });
 
     const keyringAccounts = ['0xCustodial', '0xNonCustodial'];

--- a/packages/portfolioDashboard/src/handleMmiPortfolio.ts
+++ b/packages/portfolioDashboard/src/handleMmiPortfolio.ts
@@ -7,26 +7,37 @@ export async function handleMmiPortfolio({
   extensionId,
 }) {
   const parsedNetworks = networks.map(item => parseInt(item.chainId, 16));
-  const accounts = keyringAccounts.map(address => {
-    const accountDetails = getAccountDetails(address);
 
-    if (accountDetails) {
-      // This is a custodial account
-      return {
-        address,
-        name: accountDetails.name,
-        custodyType: accountDetails.custodyType,
-      };
+  let parsedAccounts = [];
+
+  identities.forEach(identity => {
+    const isInKeyring = keyringAccounts.includes(identity.address);
+    const accountDetails = isInKeyring ? getAccountDetails(identity.address) : null;
+
+    // Check if the identity address is already in parsedAccounts to avoid duplicates
+    const isAlreadyAdded = parsedAccounts.some(account => account.address === identity.address);
+
+    if (!isAlreadyAdded) {
+      if (isInKeyring && accountDetails) {
+        // This is a custodial account
+        parsedAccounts.push({
+          address: identity.address,
+          name: accountDetails.name,
+          custodyType: accountDetails.custodyType,
+        });
+      } else {
+        // For all identities, if not custodial or not in keyringAccounts
+        parsedAccounts.push({
+          address: identity.address,
+          name: identity.name,
+          custodyType: null,
+        });
+      }
     }
-
-    const name = identities[address]?.name || null;
-
-    // This is an HD or hardware account. We should be able to get the name from the preferences controller store, but I have no idea how (@shane-t)
-    return { address, name, custodyType: null };
   });
 
   return {
-    accounts,
+    accounts: parsedAccounts,
     networks: parsedNetworks,
     metrics: {
       metaMetricsId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before we were **not returning** any name for **non-Custodial** accounts, meaning normal MM accounts or HD wallet accounts didn't have a name property.
This has been fixed and now we always return the name for any valid account, check bellow image where it's visible 2 normal MM accounts and 2 custodial accounts being passed:

![Screenshot 2024-04-29 at 16 21 41](https://github.com/consensys-vertical-apps/metamask-institutional/assets/1125631/4b925c4e-c803-454d-a6e7-495ea18ed9f3)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
