### PR TITLE
Mmi bitgo proposal to have 2 envs

### DIFF
--- a/packages/custodyKeyring/src/MmiConfiguration.test.ts
+++ b/packages/custodyKeyring/src/MmiConfiguration.test.ts
@@ -46,7 +46,7 @@ const v2custodian = {
   tokens: "All ERC-20 tokens",
   chains: ["Ethereum"],
   tags: null,
-  apiVersion: 2,
+  apiVersion: "1",
   custodianPublishesTransaction: false,
   environments: [
     {
@@ -57,9 +57,11 @@ const v2custodian = {
       websocketApiUrl: "wss://websocket.dev.metamask-institutional.io/v1/ws",
       apiBaseUrl: "https://saturn-custody.dev.metamask-institutional.io/eth",
       iconUrl: "https://saturn-custody-ui.dev.metamask-institutional.io/saturn.svg",
-      apiVersion: 2,
+      apiVersion: "1",
       custodianPublishesTransaction: false,
       isNoteToTraderSupported: true,
+      isManualTokenInputSupported: false,
+      isQRCodeSupported: false
     },
   ],
 };
@@ -160,6 +162,8 @@ describe("MmiConfigurationController", () => {
           production: v2custodian.production,
           refreshTokenUrl: v2custodian.refreshTokenUrl,
           isNoteToTraderSupported: v2custodian.environments[0].isNoteToTraderSupported,
+          isManualTokenInputSupported: v2custodian.environments[0].isManualTokenInputSupported,
+          isQRCodeSupported: v2custodian.environments[0].isQRCodeSupported,
           websocketApiUrl: "wss://websocket.dev.metamask-institutional.io/v1/ws",
           version: 2,
         },

--- a/packages/custodyKeyring/src/custodianTypes/bitgo/BitgoCustodyKeyring.ts
+++ b/packages/custodyKeyring/src/custodianTypes/bitgo/BitgoCustodyKeyring.ts
@@ -46,7 +46,8 @@ export class BitgoCustodyKeyring extends CustodyKeyring {
   };
 
   sdkFactory = (authDetails: AuthDetails, envName: string): MMISDK => {
-    const custodian = this.getCustodianFromEnvName("bitgo");
+    const custodianEnvName = envName !== "bitgo" ? "bitgo-test" : "bitgo";
+    const custodian = this.getCustodianFromEnvName(custodianEnvName);
 
     return mmiSDKFactory(BitgoCustodianApi, authDetails, this.authType, custodian.apiUrl);
   };

--- a/packages/custodyKeyring/src/interfaces/IJsonRpcCustodian.ts
+++ b/packages/custodyKeyring/src/interfaces/IJsonRpcCustodian.ts
@@ -1,4 +1,6 @@
 interface IEnvironment {
+  type: string;
+  version: number;
   refreshTokenUrl: string;
   name: string;
   displayName: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Slack reference thread: https://consensys.slack.com/archives/C029JGUQKH8/p1726763493221839?thread_ts=1721940583.862139&cid=C029JGUQKH8

Bitgo asked us to support their test env in production as well, so we added a new bitgo environment entry to prod config API as `bitgo-test`.
![Screenshot 2024-10-22 at 09 28 13](https://github.com/user-attachments/assets/4d604b7d-14a0-4ce0-bbb0-82deee68608d)
And did the necessary changes, change the new env type to be "Bitgo", in mmi configuration and in bitgo keyring if the name is not "bitgo" it means the env being requested is the test env "bitgo-test".